### PR TITLE
feat: enable update winget manifest for jdk11

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,15 @@
+name: Update microsoft/winget-pkgs for official release
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: EclipseAdoptium.Temurin.11.JDK
+          token: ${{ secrets.WINGET_TOKEN }}
+          version-regex: 'jdk-11[0-9.]+'
+          installers-regex: '\.msi$'
+          fork-user: eclipse-temurin-bot


### PR DESCRIPTION
	- only for official LTS and CPU release
	- use eclipse-temurin-bot
	- version match official release on jdk-11.*

Ref: https://github.com/adoptium/temurin-build/issues/3071